### PR TITLE
More narrow return type of withMediaTypes avoids casting in usage

### DIFF
--- a/contentgrid-hateoas-spring/src/main/java/com/contentgrid/hateoas/spring/affordances/CustomInputPayloadMetadata.java
+++ b/contentgrid-hateoas-spring/src/main/java/com/contentgrid/hateoas/spring/affordances/CustomInputPayloadMetadata.java
@@ -72,7 +72,7 @@ public class CustomInputPayloadMetadata implements InputPayloadMetadata {
     }
 
     @Override
-    public @NonNull InputPayloadMetadata withMediaTypes(@NonNull List<MediaType> mediaType) {
+    public @NonNull CustomInputPayloadMetadata withMediaTypes(@NonNull List<MediaType> mediaType) {
         return new CustomInputPayloadMetadata(delegate.withMediaTypes(mediaType), propertyModifier);
     }
 


### PR DESCRIPTION
Usage of `.withMediaTypes` currently requires unnecessary casting:

```
afford(methodOn(IamGroupsRestController.class).addGroupMember(context.realmId(), context.groupId(), null))
  .configureInput((UnaryOperator<CustomInputPayloadMetadata>) payloadMetadata -> (CustomInputPayloadMetadata) payloadMetadata.withMediaTypes(List.of(RestMediaTypes.TEXT_URI_LIST)))
```

with this PR this should (?) be reduced to:

```
afford(methodOn(IamGroupsRestController.class).addGroupMember(context.realmId(), context.groupId(), null))
  .configureInput((payloadMetadata -> payloadMetadata.withMediaTypes(List.of(RestMediaTypes.TEXT_URI_LIST)))

```
