### PR TITLE
Revert "Update dependency org.springframework.boot:spring-boot-dependencies to v3.5.0"

### DIFF
--- a/contentgrid-hateoas-spring/build.gradle
+++ b/contentgrid-hateoas-spring/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-web'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.junit.jupiter:junit-jupiter-engine'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'org.assertj:assertj-core'
 }
 

--- a/contentgrid-hateoas-spring/build.gradle
+++ b/contentgrid-hateoas-spring/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-    api platform("org.springframework.boot:spring-boot-dependencies:3.5.0")
+    api platform("org.springframework.boot:spring-boot-dependencies:3.4.6")
 
     api project(":contentgrid-pagination:contentgrid-pagination-api")
 
@@ -17,7 +17,6 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-web'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.junit.jupiter:junit-jupiter-engine'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'org.assertj:assertj-core'
 }
 


### PR DESCRIPTION
Reverts xenit-eu/contentgrid-hateoas#68

Contentgrid-captain uses snapshot build of contentgrid-hateoas, so contentgrid-hateoas was automatically setting the spring boot version of captain to 3.5.0. All builds in captain fail when using spring boot 3.5.0 due to tests that use `NoSpringSecurityConfiguration` are creating two Security filter chains (might be caused by the changed behavior of `@ConditionalOnMissingBean` https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.5-Release-Notes#miscellaneous or the update of spring-security https://github.com/spring-projects/spring-security/releases/tag/6.5.0).