### PR TITLE
add UriTemplateMatcher

### DIFF
--- a/contentgrid-hateoas-spring/src/main/java/com/contentgrid/hateoas/spring/links/UriTemplateMatcher.java
+++ b/contentgrid-hateoas-spring/src/main/java/com/contentgrid/hateoas/spring/links/UriTemplateMatcher.java
@@ -1,0 +1,69 @@
+package com.contentgrid.hateoas.spring.links;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import lombok.Builder;
+import lombok.Singular;
+import org.springframework.hateoas.Link;
+import org.springframework.web.util.UriTemplate;
+
+@Builder
+public class UriTemplateMatcher<T> {
+    @Singular
+    private final List<Matcher<T>> matchers;
+
+    public static <T> UriTemplateMatcherBuilder<T> builder() {
+        return new UriTemplateMatcherBuilder<T>();
+    }
+
+    public static class UriTemplateMatcherBuilder<T> {
+
+        public UriTemplateMatcherBuilder<T> matcherFor(UriTemplate uriTemplate, Function<Map<String, String>, T> convertor) {
+            return matcher(new Matcher<>(uriTemplate, convertor));
+        }
+
+        public UriTemplateMatcherBuilder<T> matcherFor(Link link, Function<Map<String, String>, T> convertor) {
+            return matcherFor(new UriTemplate(link.getHref()), convertor);
+        }
+
+        public UriTemplateMatcherBuilder<T> matcherFor(Object invocationValue, Function<Map<String, String>, T> convertor) {
+            return matcherFor(linkTo(invocationValue).withSelfRel(), convertor);
+        }
+    }
+
+    public Collection<String> getMatchingUriTemplates() {
+        return matchers.stream()
+                .map(Matcher::uriTemplate)
+                .map(UriTemplate::toString)
+                .toList();
+    }
+
+    public Optional<T> tryMatch(String uri) {
+        for (var matcher : matchers) {
+            var matchResult = matcher.tryMatch(uri);
+            if(matchResult.isPresent()) {
+                return matchResult;
+            }
+        }
+        return Optional.empty();
+    }
+
+    private record Matcher<T>(
+            UriTemplate uriTemplate,
+            Function<Map<String, String>, T> convertor
+    ) {
+        public Optional<T> tryMatch(String uri) {
+            if(uriTemplate.matches(uri)) {
+                return Optional.ofNullable(convertor.apply(uriTemplate.match(uri)));
+            }
+            return Optional.empty();
+        }
+    }
+
+
+}

--- a/contentgrid-hateoas-spring/src/test/java/com/contentgrid/hateoas/spring/affordances/AffordanceCustomizerTest.java
+++ b/contentgrid-hateoas-spring/src/test/java/com/contentgrid/hateoas/spring/affordances/AffordanceCustomizerTest.java
@@ -1,11 +1,9 @@
-package com.contengrid.hateoas.spring.affordances;
+package com.contentgrid.hateoas.spring.affordances;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
-import com.contengrid.hateoas.spring.affordances.AffordanceCustomizerTest.TestRestController;
-import com.contentgrid.hateoas.spring.affordances.AffordanceCustomizer;
-import com.contentgrid.hateoas.spring.affordances.Affordances;
+import com.contentgrid.hateoas.spring.affordances.AffordanceCustomizerTest.TestRestController;
 import com.contentgrid.hateoas.spring.affordances.property.modifier.PropertyModifier;
 import lombok.Data;
 import lombok.EqualsAndHashCode;

--- a/contentgrid-hateoas-spring/src/test/java/com/contentgrid/hateoas/spring/affordances/AffordancesTest.java
+++ b/contentgrid-hateoas-spring/src/test/java/com/contentgrid/hateoas/spring/affordances/AffordancesTest.java
@@ -1,11 +1,9 @@
-package com.contengrid.hateoas.spring.affordances;
+package com.contentgrid.hateoas.spring.affordances;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
-import com.contengrid.hateoas.spring.affordances.AffordanceCustomizerTest.TestRestController;
-import com.contentgrid.hateoas.spring.affordances.AffordanceCustomizer;
-import com.contentgrid.hateoas.spring.affordances.Affordances;
+import com.contentgrid.hateoas.spring.affordances.AffordanceCustomizerTest.TestRestController;
 import com.contentgrid.hateoas.spring.affordances.property.modifier.PropertyModifier;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;

--- a/contentgrid-hateoas-spring/src/test/java/com/contentgrid/hateoas/spring/affordances/configuration/OptionsMetadataTest.java
+++ b/contentgrid-hateoas-spring/src/test/java/com/contentgrid/hateoas/spring/affordances/configuration/OptionsMetadataTest.java
@@ -1,12 +1,11 @@
-package com.contengrid.hateoas.spring.affordances.configuration;
+package com.contentgrid.hateoas.spring.affordances.configuration;
 
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 import com.contentgrid.hateoas.spring.affordances.AffordanceCustomizer;
 import com.contentgrid.hateoas.spring.affordances.Affordances;
-import com.contentgrid.hateoas.spring.affordances.configuration.OptionsMetadata;
 import com.contentgrid.hateoas.spring.affordances.property.modifier.PropertyModifier;
-import com.contengrid.hateoas.spring.affordances.configuration.OptionsMetadataTest.TestController;
+import com.contentgrid.hateoas.spring.affordances.configuration.OptionsMetadataTest.TestController;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -23,7 +22,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.MediaTypes;

--- a/contentgrid-hateoas-spring/src/test/java/com/contentgrid/hateoas/spring/affordances/property/CustomInputPayloadMetadataTest.java
+++ b/contentgrid-hateoas-spring/src/test/java/com/contentgrid/hateoas/spring/affordances/property/CustomInputPayloadMetadataTest.java
@@ -1,12 +1,9 @@
-package com.contengrid.hateoas.spring.affordances.property;
+package com.contentgrid.hateoas.spring.affordances.property;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.contentgrid.hateoas.spring.affordances.CustomInputPayloadMetadata;
 import com.contentgrid.hateoas.spring.affordances.property.modifier.PropertyModifier;
-import com.contentgrid.hateoas.spring.affordances.property.CustomPropertyMetadata;
-import com.contentgrid.hateoas.spring.affordances.property.PropertyMetadataWithAllowedValues;
-import com.contentgrid.hateoas.spring.affordances.property.PropertyMetadataWithSelectedValue;
 import java.util.List;
 import lombok.Data;
 import org.junit.jupiter.api.Test;

--- a/contentgrid-hateoas-spring/src/test/java/com/contentgrid/hateoas/spring/affordances/property/CustomPropertyMetadataTest.java
+++ b/contentgrid-hateoas-spring/src/test/java/com/contentgrid/hateoas/spring/affordances/property/CustomPropertyMetadataTest.java
@@ -1,10 +1,7 @@
-package com.contengrid.hateoas.spring.affordances.property;
+package com.contentgrid.hateoas.spring.affordances.property;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.contentgrid.hateoas.spring.affordances.property.CustomPropertyMetadata;
-import com.contentgrid.hateoas.spring.affordances.property.PropertyMetadataWithAllowedValues;
-import com.contentgrid.hateoas.spring.affordances.property.PropertyMetadataWithSelectedValue;
 import java.util.List;
 import lombok.Data;
 import org.junit.jupiter.api.Test;

--- a/contentgrid-hateoas-spring/src/test/java/com/contentgrid/hateoas/spring/links/UriTemplateMatcherTest.java
+++ b/contentgrid-hateoas-spring/src/test/java/com/contentgrid/hateoas/spring/links/UriTemplateMatcherTest.java
@@ -1,0 +1,54 @@
+package com.contentgrid.hateoas.spring.links;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.web.util.UriTemplate;
+
+class UriTemplateMatcherTest {
+
+    private final UriTemplateMatcher<Map<String, String>> uriTemplateMatcher = UriTemplateMatcher.<Map<String, String>>builder()
+            .matcherFor(new UriTemplate("http://test.example.com/"), params -> params) // no params
+            .matcherFor(new UriTemplate("http://test.example.com/items/{itemId}"), params -> params) // path param
+            .matcherFor(new UriTemplate("http://test.example.com/items/{itemId}/{property}/{propertyId}"), params -> params) // multiple path params
+            .build();
+
+    static Stream<Arguments> validUris() {
+        return Stream.of(
+                Arguments.of("http://test.example.com/", Map.of()),
+                Arguments.of("http://test.example.com/items/0", Map.of("itemId", "0")),
+                Arguments.of("http://test.example.com/items/foo%40bar", Map.of("itemId", "foo%40bar")), // foo@bar
+                Arguments.of("http://test.example.com/items/0/test/1", Map.of("itemId", "0", "property", "test", "propertyId", "1"))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void validUris(String uri, Map<String, String> expected) {
+        assertThat(uriTemplateMatcher.tryMatch(uri)).hasValueSatisfying(actual -> {
+            assertThat(actual).isEqualTo(expected);
+        });
+    }
+
+    static Stream<String> invalidUris() {
+        return Stream.of(
+                "/items/0", // no origin
+                "http://test.example.com", // missing '/'
+                "https://test.example.com/items/0", // https instead of http
+                "http://example.com/items/0", // invalid host
+                "http://test.example.com/items/0/test", // missing propertyId
+                "http://test.example.com/items/0/test/foo/bar" // path too long
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void invalidUris(String uri) {
+        assertThat(uriTemplateMatcher.tryMatch(uri)).isEmpty();
+    }
+
+}


### PR DESCRIPTION
The UriTemplateMatcher is used for matching uris with UriTemplates where each template maps the matched parameters to a desired output representation [ACC-2143].

[ACC-2143]: https://xenitsupport.jira.com/browse/ACC-2143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ