### PR TITLE
[ACC-2156] bundle artifacts into single upload

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,8 @@
+apply from: "gradle/jreleaser.gradle"
+
 allprojects {
     pluginManager.withPlugin('maven-publish') {
         apply from: "${rootDir}/gradle/publish.gradle"
-        apply from: "${rootDir}/gradle/jreleaser.gradle"
     }
     pluginManager.withPlugin('java-library') {
         java {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 allprojects {
     pluginManager.withPlugin('maven-publish') {
         apply from: "${rootDir}/gradle/publish.gradle"
+        apply from: "${rootDir}/gradle/jreleaser.gradle"
     }
     pluginManager.withPlugin('java-library') {
         java {

--- a/gradle/jreleaser.gradle
+++ b/gradle/jreleaser.gradle
@@ -1,3 +1,4 @@
+apply plugin: 'base'
 apply plugin: 'org.jreleaser'
 
 jreleaser {

--- a/gradle/jreleaser.gradle
+++ b/gradle/jreleaser.gradle
@@ -1,0 +1,42 @@
+apply plugin: 'org.jreleaser'
+
+jreleaser {
+    deploy {
+        maven {
+            mavenCentral {
+                sonatype {
+                    active = 'RELEASE'
+                    url = 'https://central.sonatype.com/api/v1/publisher'
+                    sign = false
+                    applyMavenCentralRules = true
+                    stagingRepository('build/staging-deploy')
+                    namespace = 'com.contentgrid'
+                }
+            }
+            nexus2 {
+                'sonatype-snapshot' {
+                    active = 'SNAPSHOT'
+                    snapshotUrl = 'https://central.sonatype.com/repository/maven-snapshots/'
+                    sign = false
+                    applyMavenCentralRules = true
+                    snapshotSupported = true
+                    closeRepository = true
+                    releaseRepository = true
+                    stagingRepository('build/staging-deploy')
+                }
+            }
+        }
+    }
+    // It is required to configure at least one release provider.
+    // But you can provide any non-existing non-empty GitHub token and skip creating tags and releases.
+    // see https://github.com/jreleaser/jreleaser/discussions/1725
+    gitRootSearch = true
+    release {
+        github {
+            enabled = true
+            skipTag = true
+            skipRelease = true
+            token = '__UNUSED__'
+        }
+    }
+}

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'signing'
-apply plugin: 'org.jreleaser'
 
 publishing {
     publications {
@@ -34,48 +33,7 @@ publishing {
 
     repositories {
         maven {
-            url = layout.buildDirectory.dir('staging-deploy')
-        }
-    }
-}
-
-jreleaser {
-    deploy {
-        maven {
-            mavenCentral {
-                sonatype {
-                    active = 'RELEASE'
-                    url = 'https://central.sonatype.com/api/v1/publisher'
-                    sign = false
-                    applyMavenCentralRules = true
-                    stagingRepository('build/staging-deploy')
-                    namespace = 'com.contentgrid'
-                }
-            }
-            nexus2 {
-                'sonatype-snapshot' {
-                    active = 'SNAPSHOT'
-                    snapshotUrl = 'https://central.sonatype.com/repository/maven-snapshots/'
-                    sign = false
-                    applyMavenCentralRules = true
-                    snapshotSupported = true
-                    closeRepository = true
-                    releaseRepository = true
-                    stagingRepository('build/staging-deploy')
-                }
-            }
-        }
-    }
-    // It is required to configure at least one release provider.
-    // But you can provide any non-existing non-empty GitHub token and skip creating tags and releases.
-    // see https://github.com/jreleaser/jreleaser/discussions/1725
-    gitRootSearch = true
-    release {
-        github {
-            enabled = true
-            skipTag = true
-            skipRelease = true
-            token = '__UNUSED__'
+            url = layout.buildDirectory.dir("staging-deploy")
         }
     }
 }

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -33,7 +33,7 @@ publishing {
 
     repositories {
         maven {
-            url = layout.buildDirectory.dir("staging-deploy")
+            url = uri("${rootDir}/build/staging-deploy")
         }
     }
 }


### PR DESCRIPTION
- Let `./gradlew publish` place all artifacts to same staging directory.
- Only configure jreleaser for the root project instead of the sub-projects. So that the deploy step uploads and publishes a single zip containing all the artifacts that need to be published.