### PR TITLE
add ExtendedHtmlInputTypeFactory

### DIFF
--- a/contentgrid-hateoas-spring/src/main/java/com/contentgrid/hateoas/spring/mediatype/html/ExtendedHtmlInputTypeFactory.java
+++ b/contentgrid-hateoas-spring/src/main/java/com/contentgrid/hateoas/spring/mediatype/html/ExtendedHtmlInputTypeFactory.java
@@ -1,0 +1,53 @@
+package com.contentgrid.hateoas.spring.mediatype.html;
+
+import java.io.File;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.hateoas.mediatype.InputTypeFactory;
+import org.springframework.hateoas.mediatype.html.HtmlInputType;
+import org.springframework.lang.Nullable;
+
+/**
+ * An extended {@link InputTypeFactory} based on {@link HtmlInputType}, with additional support
+ * for a set of unmapped types:
+ * <ul>
+ *     <li>{@link Boolean} maps to {@code checkbox}</li>
+ *     <li>{@link Instant} maps to {@code datetime}</li>
+ *     <li>{@link File} maps to {@code file}</li>
+ *     <li>{@link UUID} maps to {@code text}</li>
+ * </ul>
+ */
+@Slf4j
+class ExtendedHtmlInputTypeFactory implements InputTypeFactory {
+
+	@Nullable
+	@Override
+	public String getInputType(Class<?> type) {
+
+		HtmlInputType inputType = HtmlInputType.from(type);
+
+		if (Boolean.class.equals(type) || boolean.class.equals(type)) {
+			inputType = HtmlInputType.CHECKBOX;
+		}
+
+		if (Instant.class.equals(type)) {
+			return "datetime";
+		}
+
+		if (File.class.equals(type)) {
+			inputType = HtmlInputType.FILE;
+		}
+
+		if (UUID.class.equals(type)) {
+			inputType = HtmlInputType.TEXT;
+		}
+
+		if (inputType == null) {
+			log.trace("Type {} not mapped", type.getSimpleName());
+			return null;
+		}
+
+		return inputType.value();
+	}
+}

--- a/contentgrid-hateoas-spring/src/main/resources/META-INF/spring.factories
+++ b/contentgrid-hateoas-spring/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.hateoas.mediatype.InputTypeFactory=\
+ com.contentgrid.hateoas.spring.mediatype.html.ExtendedHtmlInputTypeFactory

--- a/contentgrid-hateoas-spring/src/test/java/com/contentgrid/hateoas/spring/affordances/property/CustomInputPayloadMetadataTest.java
+++ b/contentgrid-hateoas-spring/src/test/java/com/contentgrid/hateoas/spring/affordances/property/CustomInputPayloadMetadataTest.java
@@ -9,6 +9,7 @@ import lombok.Data;
 import org.junit.jupiter.api.Test;
 import org.springframework.hateoas.AffordanceModel.PropertyMetadata;
 import org.springframework.hateoas.MediaTypes;
+import org.springframework.hateoas.mediatype.html.HtmlInputType;
 
 class CustomInputPayloadMetadataTest {
 
@@ -28,13 +29,37 @@ class CustomInputPayloadMetadataTest {
 
         assertThat(payloadMetadata.getType()).isEqualTo(DataClass.class);
         assertThat(payloadMetadata.stream())
-                .map(PropertyMetadata::getName)
-                .containsExactlyInAnyOrder("title", "optA", "optB");
+                .satisfiesExactlyInAnyOrder(
+                        title -> {
+                            assertThat(title.getName()).isEqualTo("title");
+                            assertThat(title.getInputType()).isEqualTo(HtmlInputType.TEXT_VALUE);
+                        },
+                        optA -> {
+                            assertThat(optA.getName()).isEqualTo("optA");
+                            assertThat(optA.getInputType()).isEqualTo(HtmlInputType.CHECKBOX_VALUE);
+                        },
+                        optB -> {
+                            assertThat(optB.getName()).isEqualTo("optB");
+                            assertThat(optB.getInputType()).isEqualTo(HtmlInputType.CHECKBOX_VALUE);
+                        }
+                );
 
         assertThat(withJsonMediatype.getMediaTypes()).containsExactly(MediaTypes.HAL_FORMS_JSON);
         assertThat(withJsonMediatype.stream())
-                .map(PropertyMetadata::getName)
-                .containsExactlyInAnyOrder("title", "optA", "optB");
+                .satisfiesExactlyInAnyOrder(
+                        title -> {
+                            assertThat(title.getName()).isEqualTo("title");
+                            assertThat(title.getInputType()).isEqualTo(HtmlInputType.TEXT_VALUE);
+                        },
+                        optA -> {
+                            assertThat(optA.getName()).isEqualTo("optA");
+                            assertThat(optA.getInputType()).isEqualTo(HtmlInputType.CHECKBOX_VALUE);
+                        },
+                        optB -> {
+                            assertThat(optB.getName()).isEqualTo("optB");
+                            assertThat(optB.getInputType()).isEqualTo(HtmlInputType.CHECKBOX_VALUE);
+                        }
+                );
     }
 
     @Test

--- a/contentgrid-hateoas-spring/src/test/java/com/contentgrid/hateoas/spring/mediatype/html/ExtendedHtmlInputTypeFactoryTest.java
+++ b/contentgrid-hateoas-spring/src/test/java/com/contentgrid/hateoas/spring/mediatype/html/ExtendedHtmlInputTypeFactoryTest.java
@@ -1,0 +1,36 @@
+package com.contentgrid.hateoas.spring.mediatype.html;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.hateoas.mediatype.InputTypeFactory;
+
+class ExtendedHtmlInputTypeFactoryTest {
+
+    InputTypeFactory inputTypeFactory = new ExtendedHtmlInputTypeFactory();
+
+    @ParameterizedTest
+    @CsvSource({
+            "java.lang.String,text",
+            "java.lang.Short,number",
+            "java.lang.Integer,number",
+            "java.lang.Long,number",
+            "java.lang.Float,number",
+            "java.lang.Double,number",
+            "java.math.BigDecimal,number",
+            "java.lang.Boolean,checkbox",
+            "java.time.LocalDate,date",
+            "java.time.LocalDateTime,datetime-local",
+            "java.time.LocalTime,time",
+            "java.time.Instant,datetime",
+            "java.util.UUID,text",
+            "java.net.URI,url",
+            "java.net.URL,url",
+            "java.io.File,file"
+    })
+    void testInputType(Class<?> clazz, String inputType) {
+        assertThat(inputTypeFactory.getInputType(clazz)).isEqualTo(inputType);
+    }
+
+}


### PR DESCRIPTION
ExtendedHtmlInputTypeFactory adds following support:
- booleans map to `checkbox`
- `java.time.Instant` maps to `datetime`
- `java.io.File` maps to `file`
- `java.util.UUID` maps to `text`

Copied from https://github.com/xenit-eu/contentgrid-spring/blob/main/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/mediatype/html/ContentGridHtmlInputTypeFactory.java